### PR TITLE
Issue 6: Add the ability to restart question sets

### DIFF
--- a/app/controllers/questionset.py
+++ b/app/controllers/questionset.py
@@ -80,6 +80,17 @@ def register(app):
 
         return json.dumps(True)
 
+    @app.route('/questionset/<id>/toggle/<mode>', methods = ['POST'])
+    @lib.authenticated
+    def update_questionset_modes(id, mode):
+
+        questionset = models.QuestionSet(id)
+
+        state = flask.request.form['state']
+        questionset['mode-{}'.format(mode)] = json.loads(state)
+
+        return json.dumps(True)
+
     @app.route('/questionset/<id>/cron-hour', methods = ['POST'])
     @lib.authenticated
     def update_questionset_cron_hour(id):

--- a/app/templates/questionset.html
+++ b/app/templates/questionset.html
@@ -24,6 +24,12 @@
     <span class="item editable" data-title="next-send-date" data-url="/questionset/{{ questionset['id'] }}/next-send-date">{{ questionset['next-send-date'] }}</span>
 </div>
 
+<h3>Options</h2>
+<div id="viewOptions">
+    <p><input class="item toggleable" data-url="/questionset/{{ questionset['id'] }}/toggle/restart" name="mode-restart" type="checkbox" {% if questionset['mode-restart'] %}checked{% endif %} />Restart when finished</p>
+    <p><input class="item toggleable" data-url="/questionset/{{ questionset['id'] }}/toggle/shuffle" name="mode-shuffle" type="checkbox" {% if questionset['mode-shuffle'] %}checked{% endif %} />Shuffle on restart</p>
+</div>
+
 <h3>Question Hour (UTC)</h2>
 <div id="viewCronHour">
     <select class="item selectable" name="cron-hour" data-url="/questionset/{{ questionset['id'] }}/cron-hour">


### PR DESCRIPTION
- mode-restart will start over after the last question is sent
- mode-shuffle will also shuffle the list when you restart
